### PR TITLE
Activate a home venv if it exists

### DIFF
--- a/zsh/common.zsh
+++ b/zsh/common.zsh
@@ -113,6 +113,9 @@ function chpwd() {
     fi
 }
 
+# If a home venv exists, turn it on
+[[ -d ~/.venv  ]] && . ~/.venv/bin/activate
+
 # Serve HTML Directory at specified port (8000 is the default)
 function serve() {
     pushd $1


### PR DESCRIPTION
I've been using a home-based venv to replace system wide pip installs. This seems to work pretty good but it needs a small tweak to automatically activate it when a shell is created.